### PR TITLE
Pixijs v5 Upgrade

### DIFF
--- a/demos/pixijs/bin/index.htm
+++ b/demos/pixijs/bin/index.htm
@@ -30,7 +30,8 @@
 </head>
 <body>
 	<canvas id="gameCanvas" disabled-config="assets/__Config.xml" fullScreen="all"></canvas>
-	<script src="pixijs.min.js"></script>
+	<script src="https://pixijs.download/v5.2.2/pixi.min.js"></script>
+	<script src="https://github.com/pixijs/pixi-sound/releases/download/v3.0.4/pixi-sound.js"></script>
 	<script src="game.js"></script>
 </body>
 </html>

--- a/lib/awe6/core/drivers/pixijs/Kernel.hx
+++ b/lib/awe6/core/drivers/pixijs/Kernel.hx
@@ -34,8 +34,8 @@ import haxe.Timer;
 import js.Browser;
 import js.html.CanvasElement;
 import js.html.Event;
-import pixi.core.renderers.Detector;
-import pixi.core.renderers.SystemRenderer;
+import pixi.core.RenderOptions;
+import pixi.core.renderers.webgl.Renderer;
 import pixi.core.ticker.Ticker;
 
 /**
@@ -49,7 +49,7 @@ class Kernel extends AKernel
 	private var _canvas:CanvasElement;
 	private var _ticker:Ticker;
 	private var _timeOfLastRender:Int;
-	private var _renderer:SystemRenderer;
+	private var _renderer:Renderer;
 	private var _scaleX:Float;
 	private var _scaleY:Float;
 	private var _prevWindowSize:String;
@@ -69,9 +69,16 @@ class Kernel extends AKernel
 		system = new System( this );
 		_scaleX = _scaleY = 1;
 		_canvas = cast( factory, Factory ).canvas;
-		_renderer = Detector.autoDetectRenderer( { view: _canvas }, isLocal || ( _canvas.getAttribute( "forceCanvas" ) == "true" ) );
-		_renderer.resize( factory.width, factory.height );
-		_renderer.backgroundColor = factory.bgColor;
+
+		// Pixijs v5 simplified Rendering pretty substantially; resize method has been made private and is always enabled
+		// Encapsulating options like this is so much easier than original implementation
+		var options:RenderOptions = {};
+		options.view = _canvas;
+		options.width = factory.width;
+		options.height = factory.height;
+		options.backgroundColor = factory.bgColor;
+
+		_renderer = new Renderer( options );
 		_canvas.addEventListener( "contextmenu", _onContextMenu, false );
 		Browser.window.addEventListener( "unload", _onUnload );
 		_ticker = Ticker.shared;

--- a/lib/awe6/core/drivers/pixijs/Kernel.hx
+++ b/lib/awe6/core/drivers/pixijs/Kernel.hx
@@ -71,7 +71,7 @@ class Kernel extends AKernel
 		_canvas = cast( factory, Factory ).canvas;
 
 		// Pixijs v5 simplified Rendering pretty substantially; resize method has been made private and is always enabled
-		// Encapsulating options like this is so much easier than original implementation
+		// Encapsulating options like this is so much cleaner than original implementation
 		var options:RenderOptions = {};
 		options.view = _canvas;
 		options.width = factory.width;

--- a/lib/awe6/core/drivers/pixijs/SceneTransition.hx
+++ b/lib/awe6/core/drivers/pixijs/SceneTransition.hx
@@ -33,7 +33,7 @@ import pixi.core.Pixi.RendererType;
 import pixi.core.Pixi.ScaleModes;
 import pixi.core.display.DisplayObject;
 import pixi.core.math.shapes.Rectangle;
-import pixi.core.renderers.SystemRenderer;
+import pixi.core.renderers.webgl.Renderer;
 import pixi.core.sprites.Sprite;
 
 /**
@@ -45,7 +45,7 @@ class SceneTransition extends ASceneTransition
 	override private function _init():Void 
 	{
 		super._init();
-		var l_renderer:SystemRenderer = untyped _kernel._renderer;
+		var l_renderer:Renderer = untyped _kernel._renderer;
 		var l_displayObject:DisplayObject = untyped _kernel.scenes.scene.view.context;
 		var l_bounds = l_displayObject.getBounds();
 		if ( ( l_renderer != null ) && ( l_displayObject != null ) )

--- a/lib/awe6/core/drivers/pixijs/System.hx
+++ b/lib/awe6/core/drivers/pixijs/System.hx
@@ -30,7 +30,7 @@
 package awe6.core.drivers.pixijs;
 import awe6.interfaces.IKernel;
 import js.Browser;
-import pixi.core.renderers.webgl.WebGLRenderer;
+import pixi.core.renderers.webgl.Renderer;
 	
 /**
  * Detects device operating system. Thanks to System.js by MrDoob, Modernizr, Richard Davey
@@ -117,7 +117,9 @@ import pixi.core.renderers.webgl.WebGLRenderer;
 	{
 		var l_renderer = untyped _kernel._renderer;
 		if ( l_renderer == null ) return false;
-		return Std.is( l_renderer, WebGLRenderer ); 
+
+		// WebGLRenderer is now just Renderer
+		return Std.is( l_renderer, Renderer ); 
 	}
 	
 	private function _cocoonOverrides()


### PR DESCRIPTION
[According to the maintainers](https://github.com/pixijs/pixi-haxe/issues/161) for the Pixijs Haxe bindings used for the Pixijs driver for this project, the current Master branch is production ready and a full  release with version 5 support should be coming relatively soon. Using the [v4 to v5 migration guide](https://github.com/pixijs/pixi.js/wiki/v5-Migration-Guide) and some testing in a separate private repo altogether, I was able to get the [Pixijs Awe6 demo to load and play](https://youtu.be/erXx3-HyHB0).

Version 5 of Pixijs has made WebGL the standard renderer with Canvas being moved to a separate `pixi.js-legacy` package for games and apps that still need fallback support. The process of using a renderer has been heavily streamlined, making some of Awe6's implementation unnecessary or redundant. Its respective Haxe bindings maintainers have removed Haxe 3 support altogether in favor of Haxe 4 being production ready. It also added physics and collision support through the [nape-haxe4](https://github.com/HaxeFlixel/nape-haxe4/) library, which I haven't used to any major extent yet.

I'm not sure what exactly changed under the hood yet that caused some minor issues for me, but here's the list of the few I ran into:

1. Downloading the latest version of `pixijs.min.js` no longer works locally. I had to link the script's url directly in the `index.htm` file to get it to work. '
2. The same issue occurred with `pixi-sound.js` plugin. It has to be linked directly in `index.htm` or sound will not load and the Preloader will error out with the loading bar frozen at about 75%.
3. When testing on any Chromium-based browser, it must be started with the `--allow-file-access-from-files` flag enabled to run the demo locally. I haven't tried hosting it from my personal yet, but apparently that's the only other way to test it out.